### PR TITLE
optional cache busting, `post_json` & bearer auth

### DIFF
--- a/src/prober/states.rs
+++ b/src/prober/states.rs
@@ -25,6 +25,8 @@ pub struct ServiceStatesProbe {
     pub status: Status,
     pub label: String,
     pub nodes: IndexMap<String, ServiceStatesProbeNode>,
+    pub bearer_token: Option<String>,
+    pub cache_busting_query_parameter: bool,
 }
 
 #[derive(Serialize)]
@@ -34,6 +36,7 @@ pub struct ServiceStatesProbeNode {
     pub mode: Mode,
     pub replicas: IndexMap<String, ServiceStatesProbeNodeReplica>,
     pub http_body_healthy_match: Option<Regex>,
+    pub post_json: Option<String>,
     pub rabbitmq_queue: Option<String>,
 }
 


### PR DESCRIPTION
Adds three new options for `HTTP` probes:

* `post_json` -- set at the node level, makes a JSON POST request instead of GET.
* `cache_busting_query_parameter` -- set at service level, optionally disables the `?<timestamp>` query parameter that gets added to requests for over-zealous validating API routes.
* `bearer_token_env_var` -- set at service level, expands an environment variable into an `Authorization: Bearer $ENV_VAR` header for the requests. We want to health check certain services that require authentication. We don't want to inject secrets into the config file, but we can do it via an environment variable (this is pretty common in e.g. a Kubernetes scenario).

Here's an example with the new settings:
```toml
[[probe.service]]
id = "api"
label = "API Routes"
cache_busting_query_parameter = false

[[probe.service.node]]
id = "labellers-predict-comments"
label = "Predict Comments"
mode = "poll"

post_json = "{\"uids\":[\"7cdeeb44cd63ae9c.16355\"]}"

replicas = ["https://reinfer.io/api/v1/datasets/dev-health-check/example/labellers/0/predict-comments"]
```