### PR TITLE
Add Telegram notifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,11 @@ lettre_email = { version = "0.9.2", optional = true }
 libstrophe = { version = "0.13", default-features = false, optional = true }
 
 [features]
-default = ["notifier-email", "notifier-twilio", "notifier-slack", "notifier-pushover", "notifier-webhook"]
+default = ["notifier-email", "notifier-twilio", "notifier-slack", "notifier-telegram", "notifier-pushover", "notifier-webhook"]
 notifier-email = ["lettre", "lettre_email"]
 notifier-twilio = []
 notifier-slack = []
+notifier-telegram = []
 notifier-pushover = []
 notifier-webhook = []
 notifier-xmpp = ["libstrophe"]

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ Use the sample [config.cfg](https://github.com/valeriansaliou/vigil/blob/master/
 * `mention_channel` (type: _boolean_, allowed: `true`, `false`, default: `false`) — Whether to mention channel when sending Slack messages (using _@channel_, which is handy to receive a high-priority notification)
 * `reminders_only` (type: _boolean_, allowed: `true`, `false`, default: `false`) — Whether to send Slack messages only for downtime reminders or everytime
 
+**[notify.telegram]**
+
+* `bot_token` (type: _string_, allowed: any strings, no default) — [Telegram bot token](https://core.telegram.org/bots/api#authorizing-your-bot)
+* `chat_id` (type: _string_, allowed: any strings, no default) — Chat id where you want Vigil to send messages. Can be group chat id (_e.g._ `"@foo"`) or user chat id (_e.g._ `"123456789"`)
+
 **[notify.pushover]**
 
 * `app_token` (type: _string_, allowed: any string, no default) — Pushover application token (you need to create a dedicated Pushover application to get one)

--- a/config.cfg
+++ b/config.cfg
@@ -92,6 +92,11 @@ reminders_only = true
 hook_url = "https://hooks.slack.com/services/xxxx"
 mention_channel = true
 
+[notify.telegram]
+
+bot_token = "xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+chat_id = "xxxxxxxxx"
+
 [notify.pushover]
 
 app_token = "xxxx"

--- a/src/aggregator/manager.rs
+++ b/src/aggregator/manager.rs
@@ -24,6 +24,9 @@ use crate::notifier::twilio::TwilioNotifier;
 #[cfg(feature = "notifier-slack")]
 use crate::notifier::slack::SlackNotifier;
 
+#[cfg(feature = "notifier-telegram")]
+use crate::notifier::telegram::TelegramNotifier;
+
 #[cfg(feature = "notifier-pushover")]
 use crate::notifier::pushover::PushoverNotifier;
 
@@ -255,6 +258,9 @@ pub fn run() {
 
                 #[cfg(feature = "notifier-slack")]
                 Notification::dispatch::<SlackNotifier>(notify, &notification).ok();
+
+                #[cfg(feature = "notifier-telegram")]
+                Notification::dispatch::<TelegramNotifier>(notify, &notification).ok();
 
                 #[cfg(feature = "notifier-pushover")]
                 Notification::dispatch::<PushoverNotifier>(notify, &notification).ok();

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -96,6 +96,7 @@ pub struct ConfigNotify {
     pub email: Option<ConfigNotifyEmail>,
     pub twilio: Option<ConfigNotifyTwilio>,
     pub slack: Option<ConfigNotifySlack>,
+    pub telegram: Option<ConfigNotifyTelegram>,
     pub pushover: Option<ConfigNotifyPushover>,
     pub xmpp: Option<ConfigNotifyXMPP>,
     pub webhook: Option<ConfigNotifyWebHook>,
@@ -159,6 +160,15 @@ pub struct ConfigNotifySlack {
     pub mention_channel: bool,
 
     #[serde(default = "defaults::notify_slack_reminders_only")]
+    pub reminders_only: bool,
+}
+
+#[derive(Deserialize)]
+pub struct ConfigNotifyTelegram {
+    pub bot_token: String,
+    pub chat_id: String,
+
+    #[serde(default = "defaults::notify_telegram_reminders_only")]
     pub reminders_only: bool,
 }
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -91,6 +91,10 @@ pub fn notify_slack_reminders_only() -> bool {
     false
 }
 
+pub fn notify_telegram_reminders_only() -> bool {
+    false
+}
+
 pub fn notify_pushover_reminders_only() -> bool {
     false
 }

--- a/src/notifier/mod.rs
+++ b/src/notifier/mod.rs
@@ -15,6 +15,9 @@ pub mod twilio;
 #[cfg(feature = "notifier-slack")]
 pub mod slack;
 
+#[cfg(feature = "notifier-telegram")]
+pub mod telegram;
+
 #[cfg(feature = "notifier-pushover")]
 pub mod pushover;
 

--- a/src/notifier/telegram.rs
+++ b/src/notifier/telegram.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+
+use super::generic::{GenericNotifier, Notification, DISPATCH_TIMEOUT_SECONDS};
+use crate::config::config::ConfigNotify;
+use crate::APP_CONF;
+
+lazy_static! {
+    static ref TELEGRAM_HTTP_CLIENT: Client = Client::builder()
+        .timeout(Duration::from_secs(DISPATCH_TIMEOUT_SECONDS))
+        .gzip(true)
+        .build()
+        .unwrap();
+}
+
+pub struct TelegramNotifier;
+
+#[derive(Serialize)]
+struct TelegramPayload<'a> {
+    chat_id: TelegramChatID<'a>,
+    text: String,
+    parse_mode: &'static str,
+    disable_web_page_preview: bool,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum TelegramChatID<'a> {
+    Group(&'a str),
+    User(u64),
+}
+
+impl GenericNotifier for TelegramNotifier {
+    fn attempt(notify: &ConfigNotify, notification: &Notification) -> Result<(), bool> {
+        if let Some(ref telegram) = notify.telegram {
+            // Build message
+            let mut message_text = if notification.changed == true {
+                format!("Status changed to *{}*.\n", notification.status.as_str())
+            } else {
+                format!("Status is still *{}*.\n", notification.status.as_str())
+            };
+
+            let mut replicas_count: HashMap<String, u32> = HashMap::new();
+
+            for replica in notification.replicas.iter() {
+                let service_and_node = replica.split(":").take(2).collect::<Vec<&str>>().join(":");
+                *replicas_count.entry(service_and_node).or_insert(0) += 1;
+            }
+
+            let nodes_count_list_text = replicas_count
+                .iter()
+                .map(|(service_and_node, count)| {
+                    format!(
+                        "- `{}`: {} {}",
+                        service_and_node,
+                        count,
+                        notification.status.as_str()
+                    )
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
+
+            message_text.push_str(&nodes_count_list_text);
+            message_text.push_str(&format!("\nLink: {}", APP_CONF.branding.page_url.as_str()));
+
+            let chat_id = match &telegram.chat_id.parse::<u64>() {
+                Ok(user_chat_id) => TelegramChatID::User(*user_chat_id),
+                Err(_) => TelegramChatID::Group(&telegram.chat_id.as_str()),
+            };
+
+            // Build payload
+            let payload = TelegramPayload {
+                chat_id: chat_id,
+                text: message_text,
+                parse_mode: "markdown",
+                disable_web_page_preview: true,
+            };
+
+            let url = format!(
+                "https://api.telegram.org/bot{}/sendMessage",
+                telegram.bot_token
+            );
+            let response = TELEGRAM_HTTP_CLIENT
+                .post(url.as_str())
+                .json(&payload)
+                .send();
+
+            if let Ok(response_inner) = response {
+                if response_inner.status().is_success() == true {
+                    return Ok(());
+                }
+            }
+
+            return Err(true);
+        }
+
+        Err(false)
+    }
+
+    fn can_notify(notify: &ConfigNotify, notification: &Notification) -> bool {
+        if let Some(ref telegram_config) = notify.telegram {
+            notification.expected(telegram_config.reminders_only)
+        } else {
+            false
+        }
+    }
+
+    fn name() -> &'static str {
+        "telegram"
+    }
+}

--- a/src/notifier/telegram.rs
+++ b/src/notifier/telegram.rs
@@ -5,6 +5,7 @@ use reqwest::blocking::Client;
 
 use super::generic::{GenericNotifier, Notification, DISPATCH_TIMEOUT_SECONDS};
 use crate::config::config::ConfigNotify;
+use crate::prober::status::Status;
 use crate::APP_CONF;
 
 lazy_static! {
@@ -36,10 +37,24 @@ impl GenericNotifier for TelegramNotifier {
     fn attempt(notify: &ConfigNotify, notification: &Notification) -> Result<(), bool> {
         if let Some(ref telegram) = notify.telegram {
             // Build message
+            let status_icon = match &notification.status {
+                Status::Dead => "\u{274c}",
+                Status::Sick => "\u{26a0}",
+                Status::Healthy => "\u{2705}",
+            };
+
             let mut message_text = if notification.changed == true {
-                format!("Status changed to *{}*.\n", notification.status.as_str())
+                format!(
+                    "{} Status changed to *{}*.\n",
+                    status_icon,
+                    notification.status.as_str()
+                )
             } else {
-                format!("Status is still *{}*.\n", notification.status.as_str())
+                format!(
+                    "{} Status is still *{}*.\n",
+                    status_icon,
+                    notification.status.as_str()
+                )
             };
 
             let mut replicas_count: HashMap<String, u32> = HashMap::new();


### PR DESCRIPTION
[Even though I know you are not fond of adding more notifiers](https://github.com/valeriansaliou/vigil/pull/40#issuecomment-533172820), I added this one for my own needs so why not attempting to merge it here. To me, Telegram is popular enough to justify having an interface to it built-in here.

The WebHook notifier is not well suited for interfacing with more complex APIs such as [Telegram's](https://core.telegram.org/bots/api#sendmessage), and I did not want to a bridge service as recommended in [README](https://github.com/valeriansaliou/vigil/blob/master/README.md#what-do-webhook-payloads-look-like) just to support this feature.

Configuration remains minimal (bot token and chat id) and results are aggregated in order to keep messages concise. Here is an example:

![image](https://user-images.githubusercontent.com/8404693/79419594-66e13780-7fb7-11ea-9ea2-7ee7cdbbf1ee.png)

No extra dependency required, _cf_ [`Cargo.toml`](https://github.com/valeriansaliou/vigil/compare/master...michaeldel:master#diff-80398c5faae3c069e4e6aa2ed11b28c0)
