### PR TITLE
notifier: add support for Gotify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,13 +46,14 @@ lettre_email = { version = "0.9", optional = true }
 libstrophe = { version = "0.13", default-features = false, optional = true }
 
 [features]
-default = ["notifier-email", "notifier-twilio", "notifier-slack", "notifier-telegram", "notifier-pushover", "notifier-webhook"]
+default = ["notifier-email", "notifier-twilio", "notifier-slack", "notifier-telegram", "notifier-pushover", "notifier-webhook", "notifier-gotify"]
 notifier-email = ["lettre", "lettre_email"]
 notifier-twilio = []
 notifier-slack = []
 notifier-telegram = []
 notifier-pushover = []
 notifier-webhook = []
+notifier-gotify = []
 notifier-xmpp = ["libstrophe"]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ _👋 You use Vigil and you want to be listed there? [Contact me](https://valeri
   * Pushover
   * XMPP
   * Webhook
+  * Gotify
 * **Generates a status page**, that you can host on your domain for your public users (eg. `https://status.example.com`)
 
 ## How does it work?
@@ -239,6 +240,12 @@ Use the sample [config.cfg](https://github.com/valeriansaliou/vigil/blob/master/
 **[notify.webhook]**
 
 * `hook_url` (type: _string_, allowed: URL, no default) — Web Hook URL (eg. `https://domain.com/webhooks/[..]`)
+
+**[notify.gotify]**
+
+* `app_url` (type: _string_, allowed: URL, no default) - Gotify endpoint without trailing slash (e.g. `https://push.gotify.net`)
+* `app_token` (type: _string_, allowed: any string, no default) — Gotify application token
+* `reminders_only` (type: _boolean_, allowed: `true`, `false`, default: `false`) — Whether to send Gotify notifications only for downtime reminders or everytime
 
 **[probe]**
 

--- a/src/aggregator/manager.rs
+++ b/src/aggregator/manager.rs
@@ -36,6 +36,9 @@ use crate::notifier::xmpp::XMPPNotifier;
 #[cfg(feature = "notifier-webhook")]
 use crate::notifier::webhook::WebHookNotifier;
 
+#[cfg(feature = "notifier-gotify")]
+use crate::notifier::gotify::GotifyNotifier;
+
 const AGGREGATE_INTERVAL_SECONDS: u64 = 10;
 
 struct BumpedStates {
@@ -310,6 +313,9 @@ fn notify(bumped_states: &BumpedStates) {
 
         #[cfg(feature = "notifier-webhook")]
         Notification::dispatch::<WebHookNotifier>(notify, &notification).ok();
+
+        #[cfg(feature = "notifier-gotify")]
+        Notification::dispatch::<GotifyNotifier>(notify, &notification).ok();
     }
 }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -109,6 +109,7 @@ pub struct ConfigNotify {
     pub pushover: Option<ConfigNotifyPushover>,
     pub xmpp: Option<ConfigNotifyXMPP>,
     pub webhook: Option<ConfigNotifyWebHook>,
+    pub gotify: Option<ConfigNotifyGotify>,
 }
 
 #[derive(Deserialize)]
@@ -203,6 +204,15 @@ pub struct ConfigNotifyXMPP {
 #[derive(Deserialize)]
 pub struct ConfigNotifyWebHook {
     pub hook_url: SerdeUrl,
+}
+
+#[derive(Deserialize)]
+pub struct ConfigNotifyGotify {
+    pub app_url: String,
+    pub app_token: String,
+
+    #[serde(default = "defaults::notify_gotify_reminders_only")]
+    pub reminders_only: bool,
 }
 
 #[derive(Deserialize)]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -208,7 +208,7 @@ pub struct ConfigNotifyWebHook {
 
 #[derive(Deserialize)]
 pub struct ConfigNotifyGotify {
-    pub app_url: String,
+    pub app_url: SerdeUrl,
     pub app_token: String,
 
     #[serde(default = "defaults::notify_gotify_reminders_only")]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -114,3 +114,7 @@ pub fn notify_pushover_reminders_only() -> bool {
 pub fn notify_xmpp_reminders_only() -> bool {
     false
 }
+
+pub fn notify_gotify_reminders_only() -> bool {
+    false
+}

--- a/src/notifier/gotify.rs
+++ b/src/notifier/gotify.rs
@@ -69,8 +69,10 @@ impl GenericNotifier for GotifyNotifier {
                     return Err(true);
                 }
             }else{
-                return Ok(());
+                return Err(true);
             }
+
+            return Ok(());
 
         }
 

--- a/src/notifier/gotify.rs
+++ b/src/notifier/gotify.rs
@@ -50,7 +50,7 @@ impl GenericNotifier for GotifyNotifier {
 
             // https://gotify.net/docs/pushmsg
             // TODO: render content as markdown
-            let url = format!("{}/message?token={}", gotify.app_url, gotify.app_token);
+            let url = format!("{}/message?token={}", gotify.app_url.as_str(), gotify.app_token);
             let mut params: HashMap<&str, &str> = HashMap::new();
             params.insert("title", &APP_CONF.branding.page_title);
             params.insert("message", &message);

--- a/src/notifier/gotify.rs
+++ b/src/notifier/gotify.rs
@@ -1,0 +1,83 @@
+// Vigil
+//
+// Microservices Status Page
+// Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+
+use super::generic::{GenericNotifier, Notification, DISPATCH_TIMEOUT_SECONDS};
+use crate::config::config::ConfigNotify;
+use crate::prober::status::Status;
+use crate::APP_CONF;
+
+lazy_static! {
+    static ref GOTIFY_HTTP_CLIENT: Client = Client::builder()
+        .timeout(Duration::from_secs(DISPATCH_TIMEOUT_SECONDS))
+        .gzip(true)
+        .build()
+        .unwrap();
+}
+
+pub struct GotifyNotifier;
+
+impl GenericNotifier for GotifyNotifier {
+    fn attempt(notify: &ConfigNotify, notification: &Notification) -> Result<(), bool> {
+        if let Some(ref gotify) = notify.gotify {
+            // Build up the message text
+            let mut message = String::new();
+
+            if notification.startup == true {
+                message.push_str("<b><i>This is a startup alert.</i></b>\n\n");
+            } else if notification.changed == false {
+                message.push_str("<b><i>This is a reminder.</i></b>\n\n");
+            }
+
+            message.push_str(&format!(
+                "<u>Status:</u> <b><font color=\"{}\">{}</font></b>\n",
+                status_to_color(&notification.status),
+                notification.status.as_str().to_uppercase()
+            ));
+            message.push_str(&format!(
+                "<u>Nodes:</u> {}\n",
+                &notification.replicas.join(", ")
+            ));
+            message.push_str(&format!("<u>Time:</u> {}", &notification.time));
+
+            debug!("will send Pushover notification with message: {}", &message);
+
+            let mut has_sub_delivery_failure = false;
+
+            if has_sub_delivery_failure == true {
+                return Err(true);
+            }
+
+            return Ok(());
+        }
+
+        Err(false)
+    }
+
+    fn can_notify(notify: &ConfigNotify, notification: &Notification) -> bool {
+        if let Some(ref gotify_config) = notify.gotify {
+            notification.expected(gotify_config.reminders_only)
+        } else {
+            false
+        }
+    }
+
+    fn name() -> &'static str {
+        "gotify"
+    }
+}
+
+fn status_to_color(status: &Status) -> &'static str {
+    match status {
+        &Status::Healthy => "#54A158",
+        &Status::Sick => "#D5A048",
+        &Status::Dead => "#C4291C",
+    }
+}

--- a/src/notifier/mod.rs
+++ b/src/notifier/mod.rs
@@ -26,3 +26,6 @@ pub mod xmpp;
 
 #[cfg(feature = "notifier-webhook")]
 pub mod webhook;
+
+#[cfg(feature = "notifier-gotify")]
+pub mod gotify;


### PR DESCRIPTION
Add notifier support for [Gotify](https://gotify.net/). This initial change will only support `plain/text`.