### PR TITLE
Convert section title to link

### DIFF
--- a/res/assets/stylesheets/index.css
+++ b/res/assets/stylesheets/index.css
@@ -214,6 +214,12 @@ main section.probe .title h3 {
   display: inline-block;
 }
 
+main section.probe .title a {
+  vertical-align: middle;
+  display: inline-block;
+  color: rgba(0, 0, 0, 0.85);
+}
+
 main section.probe .title .badge {
   margin-right: 8px;
 }

--- a/res/assets/templates/index.tera
+++ b/res/assets/templates/index.tera
@@ -117,7 +117,7 @@
           <div class="title">
             <div class="badge badge-default badge-status-{{ probe.status | escape }}"></div>
 
-            <h3 class="font-sans-bold">{{ probe.label | escape }}</h3>
+            <a href="#{{probe.id}}" id="{{probe.id}}" class="font-sans-bold">{{ probe.label | escape }}</a>
           </div>
 
           <ul>

--- a/src/prober/manager.rs
+++ b/src/prober/manager.rs
@@ -677,6 +677,7 @@ pub fn initialize_store() {
     for service in &APP_CONF.probe.service {
         let mut probe = ServiceStatesProbe {
             status: Status::Healthy,
+            id: service.id.to_owned(),
             label: service.label.to_owned(),
             nodes: IndexMap::new(),
         };

--- a/src/prober/states.rs
+++ b/src/prober/states.rs
@@ -25,6 +25,7 @@ pub struct ServiceStates {
 pub struct ServiceStatesProbe {
     pub status: Status,
     pub label: String,
+    pub id: String,
     pub nodes: IndexMap<String, ServiceStatesProbeNode>,
 }
 


### PR DESCRIPTION
Hi there, 

Really impressed with this project. One thing I noticed is the status page could potentially become very long.  Because of this, I converted the probe section h3 to a link so if user wanted to jump to specific section, they could. 

For example, going to the below link would direct them to the internal section identified by the probe id.
http://localhost:8080/#internal