### PR TITLE
run polls within threads. w/ burnettk

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -48,6 +48,8 @@ script_interval = 300
 
 local_delay_dead = 40
 
+parallel_thread_limit = 2
+
 [plugins]
 
 [plugins.rabbitmq]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -94,6 +94,9 @@ pub struct ConfigMetrics {
 
     #[serde(default = "defaults::metrics_local_delay_dead")]
     pub local_delay_dead: u64,
+
+    #[serde(default = "defaults::parallel_thread_limit")]
+    pub parallel_thread_limit: u16,
 }
 
 #[derive(Deserialize)]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -73,6 +73,10 @@ pub fn metrics_local_delay_dead() -> u64 {
     40
 }
 
+pub fn parallel_thread_limit() -> u16 {
+    2
+}
+
 pub fn notify_startup_notification() -> bool {
     true
 }

--- a/src/prober/manager.rs
+++ b/src/prober/manager.rs
@@ -662,18 +662,20 @@ fn dispatch_replica<'a>(mode: DispatchMode<'a>, probe_id: &str, node_id: &str, r
 fn dispatch_polls() {
     // Probe hosts
     for probe_replica in map_poll_replicas() {
-        dispatch_replica(
-            DispatchMode::Poll(
-                &probe_replica.3,
-                &probe_replica.4,
-                &probe_replica.5,
-                &probe_replica.6,
-                &probe_replica.7,
-            ),
-            &probe_replica.0,
-            &probe_replica.1,
-            &probe_replica.2,
-        );
+        thread::spawn(move || {
+            dispatch_replica(
+                DispatchMode::Poll(
+                    &probe_replica.3,
+                    &probe_replica.4,
+                    &probe_replica.5,
+                    &probe_replica.6,
+                    &probe_replica.7,
+                ),
+                &probe_replica.0,
+                &probe_replica.1,
+                &probe_replica.2,
+            )
+        });
     }
 }
 


### PR DESCRIPTION
This just parallelizes polling jobs. In our configuration, where we have about 1000 targets being polled, we were seeing a situation where incidents and recoveries were delayed by approximately 30 minutes because of the serial polling process. Now, the entire polling process takes only as long as the maximum polling request duration, which in our case is about 10 seconds. There is a theoretical problem here, where too many requests are fired off at the same time and some limited resource is exhausted, but it hasn't been a problem for us with our 1000 polling targets. If that ever became a problem, paging could be added, but this still felt like a significant improvement over the status quo.