### PR TITLE
[Proposal] Add sorting option with sequence number

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Use the sample [config.cfg](https://github.com/valeriansaliou/vigil/blob/master/
 
 * `id` (type: _string_, allowed: any unique lowercase string, no default) — Unique identifier of the probed service node (not visible on the status page)
 * `label` (type: _string_, allowed: any string, no default) — Name of the probed service node (visible on the status page)
+* `sequence` (type: _uin16_, allowed: any number, no default) — Sort the fields based on that number
 * `mode` (type: _string_, allowed: `poll`, `push`, `script`, `local`, no default) — Probe mode for this node (ie. `poll` is direct HTTP, TCP or ICMP poll to the URLs set in `replicas`, while `push` is for Vigil Reporter nodes, `script` is used to execute a shell script and `local` is for Vigil Local nodes)
 * `replicas` (type: _array[string]_, allowed: TCP, ICMP or HTTP URLs, default: empty) — Node replica URLs to be probed (only used if `mode` is `poll`)
 * `scripts` (type: _array[string]_, allowed: shell scripts as source code, default: empty) — Shell scripts to be executed on the system as a Vigil sub-process; they are handy to build custom probes (only used if `mode` is `script`)

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -295,6 +295,7 @@ pub struct ConfigProbeServiceNode {
     pub id: String,
     pub label: String,
     pub mode: Mode,
+    pub sequence: Option<u16>,
     pub replicas: Option<Vec<String>>,
     pub scripts: Option<Vec<String>>,
 

--- a/src/prober/manager.rs
+++ b/src/prober/manager.rs
@@ -937,7 +937,14 @@ pub fn initialize_store() {
                 }
             }
 
-            probe.nodes.insert(node.id.to_owned(), probe_node);
+            match node.sequence {
+                None => {
+                    probe.nodes.insert(format!("z{}", node.id.to_owned()), probe_node);
+                }
+                Some(v) => {
+                    probe.nodes.insert(format!("{}{}", v, node.id.to_owned()), probe_node);
+                }
+            }
         }
 
         store.states.probes.insert(service.id.to_owned(), probe);

--- a/src/prober/manager.rs
+++ b/src/prober/manager.rs
@@ -939,10 +939,14 @@ pub fn initialize_store() {
 
             match node.sequence {
                 None => {
-                    probe.nodes.insert(format!("z{}", node.id.to_owned()), probe_node);
+                    probe
+                        .nodes
+                        .insert(format!("z{}", node.id.to_owned()), probe_node);
                 }
                 Some(v) => {
-                    probe.nodes.insert(format!("{}{}", v, node.id.to_owned()), probe_node);
+                    probe
+                        .nodes
+                        .insert(format!("{}{}", v, node.id.to_owned()), probe_node);
                 }
             }
         }


### PR DESCRIPTION
Try to resolve: #101

Added the sequence number to the probes and concatenate with the id, so the result will be a sorted dataset.