### PR TITLE
add retry logic to script probe, similar to poll probe

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -49,6 +49,8 @@ push_system_cpu_sick_above = 0.90
 push_system_ram_sick_above = 0.90
 
 script_interval = 300
+script_retry = 0
+script_retry_delay = 2000
 
 script_parallelism = 2
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -99,6 +99,12 @@ pub struct ConfigMetrics {
     #[serde(default = "defaults::script_parallelism")]
     pub script_parallelism: u16,
 
+    #[serde(default = "defaults::metrics_script_retry")]
+    pub script_retry: u16,
+
+    #[serde(default = "defaults::metrics_script_retry_delay")]
+    pub script_retry_delay: u64,
+
     #[serde(default = "defaults::metrics_local_delay_dead")]
     pub local_delay_dead: u64,
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -77,6 +77,14 @@ pub fn script_parallelism() -> u16 {
     2
 }
 
+pub fn metrics_script_retry() -> u16 {
+    0
+}
+
+pub fn metrics_script_retry_delay() -> u64 {
+    2000
+}
+
 pub fn metrics_local_delay_dead() -> u64 {
     40
 }


### PR DESCRIPTION
this change adds support for retrying script probes. to preserve the current behaviour, the default retry count is zero. the delay between retries can be configured as well.