### PR TITLE
Feature/telegram message thread

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -116,6 +116,7 @@ api_url = "https://domain.zulipchat.com/api/v1/"
 
 bot_token = "xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 chat_id = "xxxxxxxxx"
+# message_thread_id = 3
 
 [notify.pushover]
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -246,6 +246,7 @@ pub struct ConfigNotifyZulip {
 pub struct ConfigNotifyTelegram {
     pub bot_token: String,
     pub chat_id: String,
+    pub message_thread_id: Option<i64>,
 
     #[serde(default = "defaults::notify_generic_reminders_only")]
     pub reminders_only: bool,

--- a/src/notifier/telegram.rs
+++ b/src/notifier/telegram.rs
@@ -28,6 +28,8 @@ pub struct TelegramNotifier;
 #[derive(Serialize)]
 struct TelegramPayload<'a> {
     chat_id: TelegramChatID<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_thread_id: Option<i64>,
     text: String,
     parse_mode: &'static str,
     disable_web_page_preview: bool,
@@ -98,6 +100,7 @@ impl GenericNotifier for TelegramNotifier {
             // Build payload
             let payload = TelegramPayload {
                 chat_id: chat_id,
+                message_thread_id: telegram.message_thread_id,
                 text: message,
                 parse_mode: "markdown",
                 disable_web_page_preview: true,


### PR DESCRIPTION
This commit adds support for the `message_thread_id` parameter in the Telegram notifier. This allows sending notifications to a specific topic within a Telegram group.

The following changes were made:
- Added `message_thread_id: Option<i64>` to the `ConfigNotifyTelegram` struct in `src/config/config.rs`.
- Added `message_thread_id: Option<i64>` to the `TelegramPayload` struct in `src/notifier/telegram.rs` with `#[serde(skip_serializing_if = "Option::is_none")]`.
- Updated the `attempt` function in `src/notifier/telegram.rs` to pass the `message_thread_id` to the `TelegramPayload`.