### PR TITLE
feat: add native subpath support via server.path_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ You can also use environment variables with string interpolation in your configu
 * `inet` (type: _string_, allowed: IPv4 / IPv6 + port, default: `[::1]:8080`) — Host and TCP port the Vigil public status page should listen on
 * `workers` (type: _integer_, allowed: any number, default: `4`) — Number of workers for the Vigil public status page to run on
 * `mcp_server` (type: _boolean_, allowed: `true`, `false`, default: `false`) — Whether to enable MCP server or not (allows AI Agents to access public data from probes on HTTP path: `/mcp/probes`)
+* `path_prefix` (type: _string_, allowed: subpath starting with slash, default: empty) — Path prefix (ie. subpath) under which Vigil should serve all routes and assets (optional)
 * `manager_token` (type: _string_, allowed: secret token, default: no default) — Manager secret token (ie. secret password)
 * `reporter_token` (type: _string_, allowed: secret token, default: no default) — Reporter secret token (ie. secret password)
 

--- a/config.cfg
+++ b/config.cfg
@@ -12,6 +12,8 @@ workers = 4
 
 mcp_server = true
 
+# path_prefix = ""
+
 manager_token = "REPLACE_THIS_WITH_A_VERY_SECRET_KEY"
 reporter_token = "REPLACE_THIS_WITH_A_SECRET_KEY"
 

--- a/res/assets/javascripts/index.js
+++ b/res/assets/javascripts/index.js
@@ -22,7 +22,7 @@ var IndexManager = (function() {
     __schedule_refresh : function() {
       setTimeout(function() {
         IndexManager.__load(
-          "/status/text/", "text",
+          (window.PATH_PREFIX || "") + "/status/text/", "text",
 
           IndexManager.__handle_status_text_done_from_request,
           IndexManager.__handle_status_text_error
@@ -41,7 +41,7 @@ var IndexManager = (function() {
         window.STATUS_GENERAL = status;
 
         IndexManager.__load(
-          "/", "document",
+          (window.PATH_PREFIX || "") + "/", "document",
 
           IndexManager.__handle_base_done,
           IndexManager.__handle_base_error

--- a/res/assets/stylesheets/common.css
+++ b/res/assets/stylesheets/common.css
@@ -2,28 +2,28 @@
 
 @font-face {
   font-family: "Vigil Open Sans Light";
-  src: url("/assets/fonts/open_sans/open_sans_light.woff2") format("woff2"), url("/assets/fonts/open_sans/open_sans_light.woff") format("woff");
+  src: url("../fonts/open_sans/open_sans_light.woff2") format("woff2"), url("../fonts/open_sans/open_sans_light.woff") format("woff");
   font-weight: 100;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Vigil Open Sans Regular";
-  src: url("/assets/fonts/open_sans/open_sans_regular.woff2") format("woff2"), url("/assets/fonts/open_sans/open_sans_regular.woff") format("woff");
+  src: url("../fonts/open_sans/open_sans_regular.woff2") format("woff2"), url("../fonts/open_sans/open_sans_regular.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Vigil Open Sans Semibold";
-  src: url("/assets/fonts/open_sans/open_sans_semibold.woff2") format("woff2"), url("/assets/fonts/open_sans/open_sans_semibold.woff") format("woff");
+  src: url("../fonts/open_sans/open_sans_semibold.woff2") format("woff2"), url("../fonts/open_sans/open_sans_semibold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Vigil Open Sans Bold";
-  src: url("/assets/fonts/open_sans/open_sans_bold.woff2") format("woff2"), url("/assets/fonts/open_sans/open_sans_bold.woff") format("woff");
+  src: url("../fonts/open_sans/open_sans_bold.woff2") format("woff2"), url("../fonts/open_sans/open_sans_bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
@@ -194,11 +194,11 @@ a:hover {
 }
 
 .badge.badge-status-healthy.badge-default {
-  background-image: url("/assets/images/badges/icon-healthy-default.svg");
+  background-image: url("../images/badges/icon-healthy-default.svg");
 }
 
 .badge.badge-status-healthy.badge-large {
-  background-image: url("/assets/images/badges/icon-healthy-large.svg");
+  background-image: url("../images/badges/icon-healthy-large.svg");
 }
 
 .status-healthy-background,
@@ -220,12 +220,12 @@ a:hover {
 
 .badge-status-sick.badge-default,
 .badge-status-partial.badge-default {
-  background-image: url("/assets/images/badges/icon-sick-default.svg");
+  background-image: url("../images/badges/icon-sick-default.svg");
 }
 
 .badge-status-sick.badge-large,
 .badge-status-partial.badge-large {
-  background-image: url("/assets/images/badges/icon-sick-large.svg");
+  background-image: url("../images/badges/icon-sick-large.svg");
 }
 
 .status-sick-background,
@@ -251,11 +251,11 @@ a:hover {
 }
 
 .badge-status-dead.badge-default {
-  background-image: url("/assets/images/badges/icon-dead-default.svg");
+  background-image: url("../images/badges/icon-dead-default.svg");
 }
 
 .badge-status-dead.badge-large {
-  background-image: url("/assets/images/badges/icon-dead-large.svg");
+  background-image: url("../images/badges/icon-dead-large.svg");
 }
 
 .status-dead-background,

--- a/res/assets/templates/index.tera
+++ b/res/assets/templates/index.tera
@@ -14,13 +14,14 @@
 
     <title>{{ config.page_title | escape }}</title>
 
-    <link rel="stylesheet" href="/assets/stylesheets/common.css?v={{ config.runtime_version | escape }}" type="text/css" />
-    <link rel="stylesheet" href="/assets/stylesheets/index.css?v={{ config.runtime_version | escape }}" type="text/css" />
+    <link rel="stylesheet" href="{{ config.path_prefix }}/assets/stylesheets/common.css?v={{ config.runtime_version | escape }}" type="text/css" />
+    <link rel="stylesheet" href="{{ config.path_prefix }}/assets/stylesheets/index.css?v={{ config.runtime_version | escape }}" type="text/css" />
 
-    <script src="/assets/javascripts/index.js?v={{ config.runtime_version | escape }}" type="text/javascript"></script>
+    <script src="{{ config.path_prefix }}/assets/javascripts/index.js?v={{ config.runtime_version | escape }}" type="text/javascript"></script>
 
     <script type="text/javascript">
       window.STATUS_GENERAL = "{{ states.status | escape }}";
+      window.PATH_PREFIX = "{{ config.path_prefix | safe }}";
     </script>
 
     {% if config.custom_html %}
@@ -32,7 +33,7 @@
     <header>
       <div class="wrapper">
         <div class="header-inner">
-          <a href="/" class="logo">
+          <a href="{{ config.path_prefix }}/" class="logo">
             <img src="{{ config.logo_url | escape }}" alt="" />
 
             <span class="logo-label font-sans-semibold">Status</span>

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -38,6 +38,9 @@ pub struct ConfigServer {
     #[serde(default = "defaults::server_mcp_server")]
     pub mcp_server: bool,
 
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+
     pub manager_token: String,
     pub reporter_token: String,
 }

--- a/src/responder/context.rs
+++ b/src/responder/context.rs
@@ -27,7 +27,10 @@ lazy_static! {
         website_url: APP_CONF.branding.website_url.to_owned(),
         support_url: APP_CONF.branding.support_url.to_owned(),
         custom_html: APP_CONF.branding.custom_html.to_owned(),
-        path_prefix: match APP_CONF.server.path_prefix.as_deref()
+        path_prefix: match APP_CONF
+            .server
+            .path_prefix
+            .as_deref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
         {

--- a/src/responder/context.rs
+++ b/src/responder/context.rs
@@ -27,6 +27,19 @@ lazy_static! {
         website_url: APP_CONF.branding.website_url.to_owned(),
         support_url: APP_CONF.branding.support_url.to_owned(),
         custom_html: APP_CONF.branding.custom_html.to_owned(),
+        path_prefix: match APP_CONF.server.path_prefix.as_deref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            Some(prefix) => {
+                if prefix.starts_with('/') {
+                    prefix.to_string()
+                } else {
+                    format!("/{}", prefix)
+                }
+            }
+            None => "".to_string(),
+        },
     };
     pub static ref INDEX_ENVIRONMENT: IndexContextEnvironment = IndexContextEnvironment::default();
 }
@@ -93,6 +106,7 @@ pub struct IndexContextConfig {
     pub website_url: SerdeUrl,
     pub support_url: SerdeUrl,
     pub custom_html: Option<String>,
+    pub path_prefix: String,
 }
 
 #[derive(Serialize)]

--- a/src/responder/manager.rs
+++ b/src/responder/manager.rs
@@ -142,7 +142,10 @@ pub fn run() {
             .app_data(web::Data::new(tera.clone()))
             .wrap(middleware::NormalizePath::new(TrailingSlash::Trim));
 
-        let path_prefix = APP_CONF.server.path_prefix.as_deref()
+        let path_prefix = APP_CONF
+            .server
+            .path_prefix
+            .as_deref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty());
 
@@ -158,7 +161,8 @@ pub fn run() {
             scope = scope.route("", web::get().to(routes::index_raw));
             if let Some(mcp_services) = mcp_services.clone() {
                 scope = scope.service(
-                    web::scope("/mcp").service(web::scope("/probes").service(mcp_services.0.scope())),
+                    web::scope("/mcp")
+                        .service(web::scope("/probes").service(mcp_services.0.scope())),
                 );
             }
             app = app.service(scope);
@@ -166,7 +170,8 @@ pub fn run() {
             app = register_routes!(app);
             if let Some(mcp_services) = mcp_services.clone() {
                 app = app.service(
-                    web::scope("/mcp").service(web::scope("/probes").service(mcp_services.0.scope())),
+                    web::scope("/mcp")
+                        .service(web::scope("/probes").service(mcp_services.0.scope())),
                 );
             }
         }

--- a/src/responder/manager.rs
+++ b/src/responder/manager.rs
@@ -72,75 +72,103 @@ pub fn run() {
 
     // Start the HTTP server
     let server = HttpServer::new(move || {
+        macro_rules! register_routes {
+            ($target:expr) => {
+                $target
+                    .service(routes::assets_javascripts)
+                    .service(routes::assets_stylesheets)
+                    .service(routes::assets_images)
+                    .service(routes::assets_fonts)
+                    .service(routes::badge)
+                    .service(routes::status_text)
+                    .service(routes::status_report)
+                    .service(routes::robots)
+                    .service(routes::index)
+                    .app_data(ConfigAuth::default().realm("Reporter Token"))
+                    .service(
+                        web::resource("/reporter/{probe_id}/{node_id}")
+                            .wrap(middleware_reporter_auth.clone())
+                            .guard(guard::Post())
+                            .to(routes::reporter_report),
+                    )
+                    .service(
+                        web::resource("/reporter/{probe_id}/{node_id}/{replica_id}")
+                            .wrap(middleware_reporter_auth.clone())
+                            .guard(guard::Delete())
+                            .to(routes::reporter_flush),
+                    )
+                    .service(
+                        web::resource("/manager/announcements")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Get())
+                            .to(routes::manager_announcements),
+                    )
+                    .service(
+                        web::resource("/manager/announcement")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Post())
+                            .to(routes::manager_announcement_insert),
+                    )
+                    .service(
+                        web::resource("/manager/announcement/{announcement_id}")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Delete())
+                            .to(routes::manager_announcement_retract),
+                    )
+                    .service(
+                        web::resource("/manager/prober/alerts")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Get())
+                            .to(routes::manager_prober_alerts),
+                    )
+                    .service(
+                        web::resource("/manager/prober/alerts/ignored")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Get())
+                            .to(routes::manager_prober_alerts_ignored_resolve),
+                    )
+                    .service(
+                        web::resource("/manager/prober/alerts/ignored")
+                            .wrap(middleware_manager_auth.clone())
+                            .guard(guard::Put())
+                            .to(routes::manager_prober_alerts_ignored_update),
+                    )
+            };
+        }
+
         // Mount routes to HTTP server
         // Notice: this executes as many times as there are HTTP workers.
         let mut app = App::new()
             .app_data(web::Data::new(tera.clone()))
-            .wrap(middleware::NormalizePath::new(TrailingSlash::Trim))
-            .service(routes::assets_javascripts)
-            .service(routes::assets_stylesheets)
-            .service(routes::assets_images)
-            .service(routes::assets_fonts)
-            .service(routes::badge)
-            .service(routes::status_text)
-            .service(routes::status_report)
-            .service(routes::robots)
-            .service(routes::index)
-            .app_data(ConfigAuth::default().realm("Reporter Token"))
-            .service(
-                web::resource("/reporter/{probe_id}/{node_id}")
-                    .wrap(middleware_reporter_auth.clone())
-                    .guard(guard::Post())
-                    .to(routes::reporter_report),
-            )
-            .service(
-                web::resource("/reporter/{probe_id}/{node_id}/{replica_id}")
-                    .wrap(middleware_reporter_auth.clone())
-                    .guard(guard::Delete())
-                    .to(routes::reporter_flush),
-            )
-            .service(
-                web::resource("/manager/announcements")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Get())
-                    .to(routes::manager_announcements),
-            )
-            .service(
-                web::resource("/manager/announcement")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Post())
-                    .to(routes::manager_announcement_insert),
-            )
-            .service(
-                web::resource("/manager/announcement/{announcement_id}")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Delete())
-                    .to(routes::manager_announcement_retract),
-            )
-            .service(
-                web::resource("/manager/prober/alerts")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Get())
-                    .to(routes::manager_prober_alerts),
-            )
-            .service(
-                web::resource("/manager/prober/alerts/ignored")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Get())
-                    .to(routes::manager_prober_alerts_ignored_resolve),
-            )
-            .service(
-                web::resource("/manager/prober/alerts/ignored")
-                    .wrap(middleware_manager_auth.clone())
-                    .guard(guard::Put())
-                    .to(routes::manager_prober_alerts_ignored_update),
-            );
+            .wrap(middleware::NormalizePath::new(TrailingSlash::Trim));
 
-        // Add MCP services?
-        if let Some(mcp_services) = mcp_services.clone() {
-            app = app.service(
-                web::scope("/mcp").service(web::scope("/probes").service(mcp_services.0.scope())),
-            );
+        let path_prefix = APP_CONF.server.path_prefix.as_deref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+
+        if let Some(prefix) = path_prefix {
+            let prefix_with_slash = if prefix.starts_with('/') {
+                prefix.to_string()
+            } else {
+                format!("/{}", prefix)
+            };
+
+            let mut scope = web::scope(&prefix_with_slash);
+            scope = register_routes!(scope);
+            scope = scope.route("", web::get().to(routes::index_raw));
+            if let Some(mcp_services) = mcp_services.clone() {
+                scope = scope.service(
+                    web::scope("/mcp").service(web::scope("/probes").service(mcp_services.0.scope())),
+                );
+            }
+            app = app.service(scope);
+        } else {
+            app = register_routes!(app);
+            if let Some(mcp_services) = mcp_services.clone() {
+                app = app.service(
+                    web::scope("/mcp").service(web::scope("/probes").service(mcp_services.0.scope())),
+                );
+            }
         }
 
         app

--- a/src/responder/routes.rs
+++ b/src/responder/routes.rs
@@ -32,6 +32,10 @@ use crate::APP_CONF;
 
 #[get("/")]
 async fn index(tera: Data<Tera>) -> HttpResponse {
+    index_raw(tera).await
+}
+
+pub async fn index_raw(tera: Data<Tera>) -> HttpResponse {
     // Notice acquire lock in a block to release it ASAP (ie. before template renders)
     let context = {
         IndexContext {


### PR DESCRIPTION
#### Context & Motivation
Currently, Vigil is hardcoded to run at the root of a domain (e.g.,  https://status.example.com/ ). Running it under a subpath (e.g.,  https://example.com/status ) is not fully supported because static assets, templates, manager API endpoints, and JavaScript requests assume they own the domain root.

This PR adds native subpath support via a new optional  `path_prefix`  configuration key under the  `[server]`  block.

#### Live Demonstration
A live demonstration of this feature in action can be viewed at: 
https://ajinf.my.id/status (where all routes, stylesheets, fonts, logo links, and AJAX polling calls successfully resolve under the  `/status`  subpath directory).

#### Summary of Changes
1. Config Option: Added an optional  `path_prefix`  string parameter in the  [server]  config block.
2. Backend Route Scoping: If a `path_prefix`  is configured, Actix-Web routes and MCP services are mounted under a  `web::scope(&prefix)` . The trimmed scope root path ( `""` ) is also mapped to the main index handler to handle trailing slash normalizations correctly.
3. Template Context: Normalized the prefix and passed it to the Tera templates context ( `config.path_prefix` ).
4. Front-End Prefixing:
   • Prepended  config.path_prefix  to the logo, stylesheets, and javascript links in  `index.tera` .
   • Exposed  `window.PATH_PREFIX`  to the frontend JavaScript.
   • Prepended  `window.PATH_PREFIX`  to the frontend AJAX polling endpoints in  `index.js` .
5. Asset Path Resolution: Converted hardcoded root-relative URLs ( `/assets/...` ) inside  common.css  to relative paths ( `../...` ) so fonts and badge icons resolve correctly under any custom subpath directory.
6. Docs: Added  `path_prefix`  documentation to  config.cfg  and  `README.md` .

#### Backward Compatibility
• If  `path_prefix`  is unset or set to an empty string (the default), the behavior remains byte-for-byte identical to the current root-relative deployment setup.
• Existing deployments will not notice any change.